### PR TITLE
fix: move category filter to client and a component

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -40,6 +40,7 @@
     "flowbite": "^2.3.0",
     "flowbite-svelte": "^0.46.1",
     "jsonwebtoken": "^9.0.2",
+    "phosphor-svelte": "^2.0.1",
     "postcss": "^8.4.38",
     "prettier": "^3.2.5",
     "prettier-plugin-svelte": "^3.2.2",

--- a/app/src/components/CategoryFilter.svelte
+++ b/app/src/components/CategoryFilter.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  import { Button, ButtonGroup } from "flowbite-svelte";
+  import { createEventDispatcher } from "svelte";
+  import type { Category } from "$models/sanity.model";
+  import { goto } from "$app/navigation";
+
+  export let selectedCategory: string | undefined;
+
+  const dispatch = createEventDispatcher();
+  const searchParams = new URLSearchParams();
+
+  type Categories = { keyword: string; title: Category | "Alle" }[];
+  const categories: Categories = [
+    { title: "Alle", keyword: "" },
+    { title: "Tech", keyword: "tech" },
+    { title: "Design", keyword: "design" },
+    { title: "Sosialt", keyword: "sosialt" },
+  ];
+
+  const handleCategoryChange = (category: string) => {
+    dispatch("categoryChange", category);
+
+    if (selectedCategory) {
+      searchParams.set("category", selectedCategory);
+    } else {
+      searchParams.delete("category");
+    }
+
+    goto(`?${searchParams}`, { noScroll: true });
+  };
+</script>
+
+<ButtonGroup class="mt-8 flex-col gap-2 shadow-none sm:flex-row">
+  {#each categories as { title, keyword }}
+    <Button
+      on:click={() => handleCategoryChange(keyword)}
+      class={`${selectedCategory === keyword ? "h-7 !rounded-xl border-black bg-zinc-800 text-white hover:bg-zinc-600" : "h-7 !rounded-xl border border-black "}`}
+    >
+      {title}
+    </Button>
+  {/each}
+</ButtonGroup>

--- a/app/src/components/CategoryFilter.svelte
+++ b/app/src/components/CategoryFilter.svelte
@@ -4,7 +4,7 @@
   import type { Category } from "$models/sanity.model";
   import { goto } from "$app/navigation";
 
-  export let selectedCategory: string | undefined;
+  export let selectedCategory: string;
 
   const dispatch = createEventDispatcher();
   const searchParams = new URLSearchParams();
@@ -20,8 +20,8 @@
   const handleCategoryChange = (category: string) => {
     dispatch("categoryChange", category);
 
-    if (selectedCategory) {
-      searchParams.set("category", selectedCategory);
+    if (category) {
+      searchParams.set("category", category);
     } else {
       searchParams.delete("category");
     }

--- a/app/src/components/EventCard.svelte
+++ b/app/src/components/EventCard.svelte
@@ -4,6 +4,7 @@
   import capraLogo from "$lib/assets/capra-black-small.webp";
   import frydeLogo from "$lib/assets/fryde-black-small.webp";
   import lifligLogo from "$lib/assets/liflig-black-small.webp";
+  import { ArrowRight } from "phosphor-svelte";
 
   export let event: Event;
 </script>
@@ -43,7 +44,7 @@
         </div>
         <div class="flex flex-row items-center gap-2">
           <p>Se mer</p>
-          <span class="material-icons mr-2 text-base">arrow_forward</span>
+          <ArrowRight class="mr-2" />
         </div>
       </div>
     </div>

--- a/app/src/components/EventListItem.svelte
+++ b/app/src/components/EventListItem.svelte
@@ -5,12 +5,13 @@
   import capraLogo from "$lib/assets/capra-black-small.webp";
   import frydeLogo from "$lib/assets/fryde-black-small.webp";
   import lifligLogo from "$lib/assets/liflig-black-small.webp";
+  import { ArrowRight } from "phosphor-svelte";
 
   export let event: Event;
 </script>
 
 <a
-  class="group relative flex flex-col justify-between rounded-md border border-black p-3 hover:bg-zinc-100 hover:transition-[2s] sm:flex-row"
+  class="flex flex-col justify-between rounded-md border border-black p-3 hover:bg-zinc-100 hover:transition-[2s] sm:flex-row"
   href={`/event/${event._id}`}
 >
   <div class="flex flex-col gap-3 px-0 font-light sm:flex-row sm:gap-2 sm:px-2">
@@ -24,8 +25,8 @@
       </Badge>
     </div>
   </div>
-  <div class="flex flex-row items-center justify-between gap-6 pt-4 sm:pt-0">
-    <div class="flex gap-4">
+  <div class="flex flex-row gap-6 pt-4 sm:pt-0">
+    <div class="flex items-center gap-4">
       {#if event.organisers?.includes("Capra")}
         <img class="h-5" alt="Capra-logo" src={capraLogo} />
       {/if}
@@ -35,7 +36,7 @@
       {#if event.organisers?.includes("Fryde")}
         <img class="h-5" alt="Fryde-logo" src={frydeLogo} />
       {/if}
+      <ArrowRight class="mr-2" />
     </div>
-    <span class="material-icons mr-2 text-base">arrow_forward</span>
   </div>
 </a>

--- a/app/src/components/Header.svelte
+++ b/app/src/components/Header.svelte
@@ -1,13 +1,19 @@
 <script>
   import logo from "$lib/assets/logo.webp";
   import SignInOrOut from "./SignInOrOut.svelte";
+  import { page } from "$app/stores";
 
   export let auth;
+  $: isRoot = $page.url.pathname === "/";
 </script>
 
-<header class="flex h-[100px] w-full items-center justify-between px-4 pt-2 text-white sm:px-20">
-  <a class="flex items-center justify-center gap-6 p-2 text-4xl font-semibold sm:px-0" href="/">
-    <img class="h-12 sm:h-14" alt="Animert Capra, Fryde og Liflig-logo" src={logo} />
+<header class="flex h-[100px] w-full items-center justify-between px-4 pt-2 sm:px-20">
+  <a
+    class="flex items-center justify-center gap-6 p-2 text-4xl font-semibold sm:px-0"
+    href="/"
+    class:pointer={isRoot}
+  >
+    <img class="h-12 select-none sm:h-14" alt="Animert Capra, Fryde og Liflig-logo" src={logo} />
   </a>
   <div class="flex items-center justify-end">
     <SignInOrOut {auth} />

--- a/app/src/components/SignInOrOut.svelte
+++ b/app/src/components/SignInOrOut.svelte
@@ -7,7 +7,7 @@
 
 {#if auth}
   <div class="flex flex-row items-center gap-2">
-    <img class="h-7 rounded-xl" alt="Profilbilde" src={auth.user.image} />
+    <img class="h-7 rounded-2xl" alt="Profilbilde" src={auth.user.image} />
     <span class="mr-6 hidden text-sm font-normal text-black sm:block">{auth.user.name}</span>
     <Button color="dark" size="xs" pill class="" on:click={() => signOut({ callbackUrl: "/" })}
       >Logg ut</Button

--- a/app/src/components/SignInOrOut.svelte
+++ b/app/src/components/SignInOrOut.svelte
@@ -9,10 +9,10 @@
   <div class="flex flex-row items-center gap-2">
     <img class="h-7 rounded-2xl" alt="Profilbilde" src={auth.user.image} />
     <span class="mr-6 hidden text-sm font-normal text-black sm:block">{auth.user.name}</span>
-    <Button color="dark" size="xs" pill class="" on:click={() => signOut({ callbackUrl: "/" })}
+    <Button color="dark" class="h-7" pill on:click={() => signOut({ callbackUrl: "/" })}
       >Logg ut</Button
     >
   </div>
 {:else}
-  <Button color="dark" size="xs" pill class="" on:click={() => signIn("google")}>Logg inn</Button>
+  <Button color="dark" class="h-7" pill on:click={() => signIn("google")}>Logg inn</Button>
 {/if}

--- a/app/src/lib/server/sanity/queries.ts
+++ b/app/src/lib/server/sanity/queries.ts
@@ -7,5 +7,5 @@ export const getEventContent = async ({ id }: { id: string }) => {
   return result;
 };
 
-export const futureEventsQuery = `*[_type == "event" && start > now() && (!defined($category) || category match $category)] | order(start desc)`;
+export const futureEventsQuery = `*[_type == "event" && start > now()] | order(start asc)`;
 export const pastEventsQuery = `*[_type == "event" && start <= now()] | order(start desc)`;

--- a/app/src/routes/+page.server.ts
+++ b/app/src/routes/+page.server.ts
@@ -5,11 +5,9 @@ import { client } from "$lib/sanity/client";
 
 export const load: PageServerLoad = async (event) => {
   const url = new URL(event.url);
-  const category = url.searchParams.get("category");
+  const category = url.searchParams.get("category")?.toLowerCase();
 
-  const futureEvents: Event[] = await client.fetch(futureEventsQuery, {
-    category,
-  });
+  const futureEvents: Event[] = await client.fetch(futureEventsQuery);
   const pastEvents: Event[] = await client.fetch(pastEventsQuery);
 
   return {

--- a/app/src/routes/+page.server.ts
+++ b/app/src/routes/+page.server.ts
@@ -5,7 +5,7 @@ import { client } from "$lib/sanity/client";
 
 export const load: PageServerLoad = async (event) => {
   const url = new URL(event.url);
-  const category = url.searchParams.get("category")?.toLowerCase();
+  const selectedCategory = url.searchParams.get("category")?.toLowerCase() || "";
 
   const futureEvents: Event[] = await client.fetch(futureEventsQuery);
   const pastEvents: Event[] = await client.fetch(pastEventsQuery);
@@ -13,6 +13,6 @@ export const load: PageServerLoad = async (event) => {
   return {
     futureEvents,
     pastEvents,
-    category,
+    selectedCategory,
   };
 };

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,29 +1,19 @@
 <script lang="ts">
-  import { Button, ButtonGroup } from "flowbite-svelte";
   import EventCard from "../components/EventCard.svelte";
   import type { PageData } from "./$types";
   import EventListItem from "$components/EventListItem.svelte";
+  import CategoryFilter from "../components/CategoryFilter.svelte";
 
   export let data: PageData;
-  let { futureEvents, pastEvents } = data;
-  let selectedCategory: string = data.category || "";
 
-  function updateCategory(category: string) {
-    const url = new URL(window.location.href);
-    if (category) {
-      url.searchParams.set("category", category);
-    } else {
-      url.searchParams.delete("category");
-    }
-    window.location.href = url.toString();
-  }
+  let { futureEvents, pastEvents, category } = data;
+  let selectedCategory = category;
+  let futureEventsFiltered = futureEvents;
 
-  const categories = [
-    { value: "", title: "Alle" },
-    { value: "Tech", title: "Tech" },
-    { value: "Design", title: "Design" },
-    { value: "Sosialt", title: "Sosialt" },
-  ];
+  $: futureEventsFiltered = futureEvents.filter(({ category }) => {
+    if (!selectedCategory) return true;
+    return category.toLowerCase() === selectedCategory;
+  });
 </script>
 
 <section class="pb-8">
@@ -32,21 +22,15 @@
       Kommende kurs og arrangementer
     </h1>
 
-    <ButtonGroup class="mt-8 h-7 gap-2">
-      {#each categories as category}
-        <Button
-          on:click={() => updateCategory(category.value)}
-          class={`${selectedCategory === category.value ? "!rounded-xl border-black bg-zinc-800 text-white hover:bg-zinc-600" : "!rounded-xl border border-black"}`}
-        >
-          {category.title}
-        </Button>
-      {/each}
-    </ButtonGroup>
+    <CategoryFilter
+      {selectedCategory}
+      on:categoryChange={({ detail }) => (selectedCategory = detail)}
+    />
   </div>
 
   <div class="flex flex-col gap-4 py-5">
-    {#if futureEvents.length}
-      {#each futureEvents as event}
+    {#if futureEventsFiltered.length}
+      {#each futureEventsFiltered as event}
         <EventListItem {event} />
       {/each}
     {:else}

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -6,9 +6,7 @@
 
   export let data: PageData;
 
-  let { futureEvents, pastEvents, category } = data;
-  let selectedCategory = category;
-  let futureEventsFiltered = futureEvents;
+  let { futureEvents, pastEvents, selectedCategory } = data;
 
   $: futureEventsFiltered = futureEvents.filter(({ category }) => {
     if (!selectedCategory) return true;

--- a/app/src/routes/event/[id]/+page.svelte
+++ b/app/src/routes/event/[id]/+page.svelte
@@ -11,6 +11,7 @@
   import { registrationSchema, unregistrationSchema } from "$lib/schemas/registrationSchema.js";
   import { Alert, Badge } from "flowbite-svelte";
   import EventParticipants from "$components/EventParticipants.svelte";
+  import { MapPin, Clock } from "phosphor-svelte";
 
   export let data;
 
@@ -55,15 +56,15 @@
       <p class="text-2xl">{event.summary}</p>
     {/if}
     <div class="my-6 font-light">
-      <div class="flex">
-        <span class="material-icons mr-2">schedule</span>
+      <div class="flex items-center">
+        <Clock size="1.25rem" class="mr-2" />
         <p>
           {formatDate(event.start)}
           {formatTime(event.start)}
         </p>
       </div>
-      <div class="flex">
-        <span class="material-icons mr-2">location_on</span>
+      <div class="flex items-center">
+        <MapPin size="1.25rem" class="mr-2" />
         <p>{event.place}</p>
       </div>
       <Badge class="mt-4" large color="dark">{event.category}</Badge>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      phosphor-svelte:
+        specifier: ^2.0.1
+        version: 2.0.1(svelte@4.2.12)
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -7686,6 +7689,14 @@ packages:
       '@types/estree': 1.0.5
       estree-walker: 3.0.3
       is-reference: 3.0.2
+
+  /phosphor-svelte@2.0.1(svelte@4.2.12):
+    resolution: {integrity: sha512-2Ryvaf1sfCNOF0zTQVghtxOs/6JKn9MV+e9uluNAT9wAosgNYnaBD210WcFGRrva1sF8cddv7EWSS//ITNN4mg==}
+    peerDependencies:
+      svelte: '>=3'
+    dependencies:
+      svelte: 4.2.12
+    dev: true
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}


### PR DESCRIPTION
- Flyttet kategori filter til en komponent, ble det bedre?
- Filtrering blir gjort på klienten istedenfor server for å slippe page reload
- Tatt i bruk phosphor-svelte ikoner som gjør innlastingen smudere