### PR TITLE
feature: visibility of events and some more fields

### DIFF
--- a/app/src/components/EventInfoBox.svelte
+++ b/app/src/components/EventInfoBox.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { formatDate, formatTime } from "$lib/utils";
+  import { endsOnDifferentDay, formatDate, formatTime } from "$lib/utils";
   import type { Event } from "$models/sanity.model";
-  import { CalendarBlank, Clock, MapPin } from "phosphor-svelte";
+  import { CalendarBlank, Clock, MapPin, ForkKnife, Tag } from "phosphor-svelte";
 
   export let event: Event;
 </script>
@@ -16,7 +16,10 @@
 
   <div class="flex items-center">
     <CalendarBlank class="mr-2" />
-    <span>{formatDate(event.start)}</span>
+    <span
+      >{formatDate(event.start)}
+      {endsOnDifferentDay(event.start, event.end) ? `- ${formatDate(event.end)}` : ""}</span
+    >
   </div>
 
   <div class="flex items-center">
@@ -27,5 +30,16 @@
   <div class="flex items-center">
     <MapPin class="mr-2" />
     <span>{event.place}</span>
+  </div>
+
+  {#if event.food}
+    <div class="flex items-center">
+      <ForkKnife class="mr-2" />
+      <span>{event.food}</span>
+    </div>
+  {/if}
+  <div class="flex items-center">
+    <Tag class="mr-2" />
+    <span>{event.onlyOpenForInternal ? "Kun for interne" : "Åpent for alle"}</span>
   </div>
 </div>

--- a/app/src/components/EventInfoBox.svelte
+++ b/app/src/components/EventInfoBox.svelte
@@ -40,6 +40,6 @@
   {/if}
   <div class="flex items-center">
     <Tag class="mr-2" />
-    <span>{event.onlyOpenForInternal ? "Kun for interne" : "Åpent for alle"}</span>
+    <span>{event.openForExternals ? "Åpent for alle" : "Kun for interne"}</span>
   </div>
 </div>

--- a/app/src/lib/server/sanity/queries.ts
+++ b/app/src/lib/server/sanity/queries.ts
@@ -10,5 +10,5 @@ export const getEventContent = async ({ id }: { id: string }) => {
 export const allFutureEventsQuery = `*[_type == "event" && start > now()] | order(start asc)`;
 export const allPastEventsQuery = `*[_type == "event" && start <= now()] | order(start desc)`;
 
-export const externalFutureEventsQuery = `*[_type == "event" && start > now() && !defined(onlyVisibleForInternal)] | order(start asc) `;
-export const externalPastEventsQuery = `*[_type == "event" && start <= now() && !defined(onlyVisibleForInternal)] | order(start desc)`;
+export const externalFutureEventsQuery = `*[_type == "event" && start > now() && visibleForExternals] | order(start asc) `;
+export const externalPastEventsQuery = `*[_type == "event" && start <= now() && visibleForExternals] | order(start desc)`;

--- a/app/src/lib/server/sanity/queries.ts
+++ b/app/src/lib/server/sanity/queries.ts
@@ -7,5 +7,8 @@ export const getEventContent = async ({ id }: { id: string }) => {
   return result;
 };
 
-export const futureEventsQuery = `*[_type == "event" && start > now()] | order(start asc)`;
-export const pastEventsQuery = `*[_type == "event" && start <= now()] | order(start desc)`;
+export const allFutureEventsQuery = `*[_type == "event" && start > now()] | order(start asc)`;
+export const allPastEventsQuery = `*[_type == "event" && start <= now()] | order(start desc)`;
+
+export const externalFutureEventsQuery = `*[_type == "event" && start > now() && !defined(onlyVisibleForInternal)] | order(start asc) `;
+export const externalPastEventsQuery = `*[_type == "event" && start <= now() && !defined(onlyVisibleForInternal)] | order(start desc)`;

--- a/app/src/lib/utils/index.ts
+++ b/app/src/lib/utils/index.ts
@@ -12,3 +12,7 @@ export function formatTime(date: string) {
     minute: "numeric",
   });
 }
+
+export function endsOnDifferentDay(start: string, end: string) {
+  return formatDate(start) !== formatDate(end);
+}

--- a/app/src/models/sanity.model.ts
+++ b/app/src/models/sanity.model.ts
@@ -115,8 +115,8 @@ export type Event = {
   category: Category;
   place: string;
   organisers: Array<string>;
-  onlyOpenForInternal?: boolean;
-  onlyVisibleForInternal?: boolean;
+  openForExternals?: boolean;
+  visibleForExternals?: boolean;
   allergy?: boolean;
   food?: string;
   fields?: boolean;

--- a/app/src/models/sanity.model.ts
+++ b/app/src/models/sanity.model.ts
@@ -115,8 +115,8 @@ export type Event = {
   category: Category;
   place: string;
   organisers: Array<string>;
-  openForExternals?: boolean;
-  visibleForExternals?: boolean;
+  openForExternals: boolean;
+  visibleForExternals: boolean;
   allergy?: boolean;
   food?: string;
   fields?: boolean;

--- a/app/src/models/sanity.model.ts
+++ b/app/src/models/sanity.model.ts
@@ -107,7 +107,6 @@ export type Event = {
     _type: "image";
   };
   title: string;
-  organisers: Array<string>;
   summary?: string;
   start: string;
   end: string;
@@ -115,7 +114,11 @@ export type Event = {
   maxParticipant?: number;
   category: Category;
   place: string;
+  organisers: Array<string>;
+  onlyOpenForInternal?: boolean;
+  onlyVisibleForInternal?: boolean;
   allergy?: boolean;
+  food?: string;
   fields?: boolean;
   customFields?: Array<string>;
 };

--- a/app/src/routes/+page.server.ts
+++ b/app/src/routes/+page.server.ts
@@ -1,14 +1,24 @@
 import type { PageServerLoad } from "./$types";
 import type { Event } from "$models/sanity.model";
-import { futureEventsQuery, pastEventsQuery } from "$lib/server/sanity/queries";
+import {
+  allFutureEventsQuery,
+  allPastEventsQuery,
+  externalFutureEventsQuery,
+  externalPastEventsQuery,
+} from "$lib/server/sanity/queries";
 import { client } from "$lib/sanity/client";
 
-export const load: PageServerLoad = async (event) => {
-  const url = new URL(event.url);
+export const load: PageServerLoad = async ({ url, locals }) => {
+  const auth = await locals.auth();
+
   const selectedCategory = url.searchParams.get("category")?.toLowerCase() || "";
 
-  const futureEvents: Event[] = await client.fetch(futureEventsQuery);
-  const pastEvents: Event[] = await client.fetch(pastEventsQuery);
+  const futureEvents: Event[] = await client.fetch(
+    auth?.user ? allFutureEventsQuery : externalFutureEventsQuery
+  );
+  const pastEvents: Event[] = await client.fetch(
+    auth?.user ? allPastEventsQuery : externalPastEventsQuery
+  );
 
   return {
     futureEvents,

--- a/app/src/routes/+page.svelte
+++ b/app/src/routes/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import EventCard from "../components/EventCard.svelte";
-  import type { PageData } from "./$types";
   import EventListItem from "$components/EventListItem.svelte";
   import CategoryFilter from "../components/CategoryFilter.svelte";
 
-  export let data: PageData;
+  export let data;
 
   let { futureEvents, pastEvents, selectedCategory } = data;
 

--- a/app/src/routes/event/[id]/+page.svelte
+++ b/app/src/routes/event/[id]/+page.svelte
@@ -11,9 +11,8 @@
   import { Alert, Badge } from "flowbite-svelte";
   import EventParticipants from "$components/EventParticipants.svelte";
   import EventInfoBox from "$components/EventInfoBox.svelte";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 
   const { query, options, internalParticipantNames } = data;
   const result = useQuery({ query, options });

--- a/app/src/routes/event/[id]/+page.svelte
+++ b/app/src/routes/event/[id]/+page.svelte
@@ -8,11 +8,12 @@
   import { superForm } from "sveltekit-superforms/client";
   import { zod } from "sveltekit-superforms/adapters";
   import { registrationSchema, unregistrationSchema } from "$lib/schemas/registrationSchema.js";
-  import { Alert, Badge, Button } from "flowbite-svelte";
+  import { Alert, Badge } from "flowbite-svelte";
   import EventParticipants from "$components/EventParticipants.svelte";
   import EventInfoBox from "$components/EventInfoBox.svelte";
+  import type { PageData } from "./$types";
 
-  export let data;
+  export let data: PageData;
 
   const { query, options, internalParticipantNames } = data;
   const result = useQuery({ query, options });

--- a/app/src/routes/event/[id]/+page.svelte
+++ b/app/src/routes/event/[id]/+page.svelte
@@ -58,7 +58,7 @@
     </div>
     <div class="w-full sm:w-[60%]">
       <img
-        class="h-52 w-full rounded-xl object-cover sm:h-full"
+        class="w-full rounded-xl object-cover sm:h-full"
         src={urlFor(event.image).format("webp").url()}
         alt="Bilde for arrangementet: {event.title}"
       />

--- a/studio/models/sanity.model.ts
+++ b/studio/models/sanity.model.ts
@@ -115,8 +115,8 @@ export type Event = {
   category: Category;
   place: string;
   organisers: Array<string>;
-  onlyOpenForInternal?: boolean;
-  onlyVisibleForInternal?: boolean;
+  openForExternals?: boolean;
+  visibleForExternals?: boolean;
   allergy?: boolean;
   food?: string;
   fields?: boolean;

--- a/studio/models/sanity.model.ts
+++ b/studio/models/sanity.model.ts
@@ -115,8 +115,8 @@ export type Event = {
   category: Category;
   place: string;
   organisers: Array<string>;
-  openForExternals?: boolean;
-  visibleForExternals?: boolean;
+  openForExternals: boolean;
+  visibleForExternals: boolean;
   allergy?: boolean;
   food?: string;
   fields?: boolean;

--- a/studio/models/sanity.model.ts
+++ b/studio/models/sanity.model.ts
@@ -114,7 +114,11 @@ export type Event = {
   maxParticipant?: number;
   category: Category;
   place: string;
+  organisers: Array<string>;
+  onlyOpenForInternal?: boolean;
+  onlyVisibleForInternal?: boolean;
   allergy?: boolean;
+  food?: string;
   fields?: boolean;
   customFields?: Array<string>;
 };

--- a/studio/schema.json
+++ b/studio/schema.json
@@ -615,17 +615,7 @@
         "value": {
           "type": "string"
         },
-        "optional": false
-      },
-      "organisers": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "array",
-          "of": {
-            "type": "string"
-          }
-        },
-        "optional": false
+        "optional": true
       },
       "summary": {
         "type": "objectAttribute",
@@ -678,10 +668,41 @@
         },
         "optional": false
       },
+      "organisers": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "array",
+          "of": {
+            "type": "string"
+          }
+        },
+        "optional": false
+      },
+      "onlyOpenForInternal": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "boolean"
+        },
+        "optional": true
+      },
+      "onlyVisibleForInternal": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "boolean"
+        },
+        "optional": true
+      },
       "allergy": {
         "type": "objectAttribute",
         "value": {
           "type": "boolean"
+        },
+        "optional": true
+      },
+      "food": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "string"
         },
         "optional": true
       },
@@ -806,7 +827,7 @@
         "value": {
           "type": "string"
         },
-        "optional": false
+        "optional": true
       },
       "slug": {
         "type": "objectAttribute",
@@ -814,7 +835,7 @@
           "type": "inline",
           "name": "slug"
         },
-        "optional": false
+        "optional": true
       },
       "subtitle": {
         "type": "objectAttribute",
@@ -1149,7 +1170,7 @@
           "value": {
             "type": "string"
           },
-          "optional": false
+          "optional": true
         },
         "source": {
           "type": "objectAttribute",

--- a/studio/schema.json
+++ b/studio/schema.json
@@ -678,14 +678,14 @@
         },
         "optional": false
       },
-      "onlyOpenForInternal": {
+      "openForExternals": {
         "type": "objectAttribute",
         "value": {
           "type": "boolean"
         },
         "optional": true
       },
-      "onlyVisibleForInternal": {
+      "visibleForExternals": {
         "type": "objectAttribute",
         "value": {
           "type": "boolean"

--- a/studio/schema.json
+++ b/studio/schema.json
@@ -827,7 +827,7 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "slug": {
         "type": "objectAttribute",
@@ -835,7 +835,7 @@
           "type": "inline",
           "name": "slug"
         },
-        "optional": true
+        "optional": false
       },
       "subtitle": {
         "type": "objectAttribute",
@@ -1170,7 +1170,7 @@
           "value": {
             "type": "string"
           },
-          "optional": true
+          "optional": false
         },
         "source": {
           "type": "objectAttribute",

--- a/studio/schemas/event.ts
+++ b/studio/schemas/event.ts
@@ -78,20 +78,20 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
-      name: "onlyOpenForInternal",
-      title: "Kun åpen for interne",
+      name: "openForExternals",
+      title: "Åpen for eksterne",
       description:
-        "Hvis du krysser av å denne vil det stå på arrangementet at det er kun for interne. Hvis ikke står det at det er åpent for alle.",
+        "Hvis du krysser av å denne vil det stå på arrangementet at det er åpent for alle. Hvis ikke står det at det kun er åpent for interne.",
       type: "boolean",
       options: {
         layout: "checkbox",
       },
     }),
     defineField({
-      name: "onlyVisibleForInternal",
-      title: "Kun synlig for interne",
+      name: "visibleForExternals",
+      title: "Synlig for eksterne",
       description:
-        "Hvis du krysser av å denne vil arrangementet kun vises til interne som har logget seg inn på nettsiden.",
+        "Hvis du krysser av på denne vil arrangementet være synlig for alle selv om man ikke er logget inn.",
       type: "boolean",
       options: {
         layout: "checkbox",

--- a/studio/schemas/event.ts
+++ b/studio/schemas/event.ts
@@ -98,7 +98,7 @@ export default defineType({
       },
     }),
     defineField({
-      title: "Allergier",
+      title: "Matservering og allergier",
       name: "allergy",
       description:
         "Dersom det skal serveres mat på arrangementet, kryss av på denne slik at allergier blir lagt til i påmeldingsskjemaet.",
@@ -108,11 +108,12 @@ export default defineType({
       },
     }),
     defineField({
-      title: "Mat",
+      title: "Mat/restaurant",
       name: "food",
       type: "string",
       description:
-        "Hvis det er matservering kan du også fylle inn hva slags mat som serveres eller fra hvor, så vises det på arrangementet.",
+        "Du kan også velge å fylle inn hvor det skal spises eller hva som serveres slik at det vises på arrangementet.",
+      hidden: ({ document }) => !document?.allergy,
     }),
     defineField({
       title: "Legg til egne felter",

--- a/studio/schemas/event.ts
+++ b/studio/schemas/event.ts
@@ -83,9 +83,11 @@ export default defineType({
       description:
         "Hvis du krysser av på denne vil arrangementet være synlig for alle selv om man ikke er logget inn.",
       type: "boolean",
+      initialValue: false,
       options: {
         layout: "checkbox",
       },
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       name: "openForExternals",
@@ -93,9 +95,11 @@ export default defineType({
       description:
         "Hvis du krysser av på denne vil det stå på arrangementet at det er åpent for alle. Hvis ikke står det at det kun er åpent for interne.",
       type: "boolean",
+      initialValue: false,
       options: {
         layout: "checkbox",
       },
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       title: "Matservering og allergier",
@@ -103,9 +107,11 @@ export default defineType({
       description:
         "Dersom det skal serveres mat på arrangementet, kryss av på denne slik at allergier blir lagt til i påmeldingsskjemaet.",
       type: "boolean",
+      initialValue: false,
       options: {
         layout: "checkbox",
       },
+      validation: (Rule) => Rule.required(),
     }),
     defineField({
       title: "Mat/restaurant",

--- a/studio/schemas/event.ts
+++ b/studio/schemas/event.ts
@@ -78,20 +78,20 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
-      name: "openForExternals",
-      title: "Åpen for eksterne",
+      name: "visibleForExternals",
+      title: "Synlig for eksterne",
       description:
-        "Hvis du krysser av å denne vil det stå på arrangementet at det er åpent for alle. Hvis ikke står det at det kun er åpent for interne.",
+        "Hvis du krysser av på denne vil arrangementet være synlig for alle selv om man ikke er logget inn.",
       type: "boolean",
       options: {
         layout: "checkbox",
       },
     }),
     defineField({
-      name: "visibleForExternals",
-      title: "Synlig for eksterne",
+      name: "openForExternals",
+      title: "Åpen for eksterne",
       description:
-        "Hvis du krysser av på denne vil arrangementet være synlig for alle selv om man ikke er logget inn.",
+        "Hvis du krysser av på denne vil det stå på arrangementet at det er åpent for alle. Hvis ikke står det at det kun er åpent for interne.",
       type: "boolean",
       options: {
         layout: "checkbox",

--- a/studio/schemas/event.ts
+++ b/studio/schemas/event.ts
@@ -91,7 +91,7 @@ export default defineType({
       name: "onlyVisibleForInternal",
       title: "Kun synlig for interne",
       description:
-        "Hvis du krysser av å denne vil arrangementet kun vises til interne som har logget seg inn på nettsiden. Hvis ikke vil det være synlig for alle.",
+        "Hvis du krysser av å denne vil arrangementet kun vises til interne som har logget seg inn på nettsiden.",
       type: "boolean",
       options: {
         layout: "checkbox",

--- a/studio/schemas/event.ts
+++ b/studio/schemas/event.ts
@@ -23,18 +23,19 @@ export default defineType({
     defineField({
       name: "summary",
       title: "Oppsummering",
-      type: "string",
-      description: "En kort beskrivelse av arrangementet, 2-3 setninger.",
+      type: "text",
+      rows: 4,
+      description: "En kort beskrivelse av arrangementet, ca. 2-3 setninger",
     }),
     defineField({
       name: "start",
-      title: "Startddato",
+      title: "Startddato og tidspunkt",
       type: "datetime",
       validation: (Rule) => Rule.required(),
     }),
     defineField({
       name: "end",
-      title: "Sluttdato",
+      title: "Sluttdato og tidspunkt",
       type: "datetime",
       validation: (Rule) => Rule.required(),
     }),
@@ -42,13 +43,16 @@ export default defineType({
       name: "body",
       title: "Innhold",
       type: "blockContent",
-      description: "Skriv en tekst som beskriver arrangementet i detalj.",
+      description:
+        "Skriv en tekst som beskriver arrangementet i detalj, gjerne inkludert program og all relevant info.",
       validation: (Rule) => Rule.required(),
     }),
 
     defineField({
       name: "maxParticipant",
       title: "Maks antall deltagere",
+      description:
+        "Hvis det finnes en maksgrense for antall deltagere, fyll den inn her. Hvis ikke, la denne stå tom.",
       type: "number",
     }),
     defineField({
@@ -74,12 +78,46 @@ export default defineType({
       validation: (Rule) => Rule.required(),
     }),
     defineField({
-      title: "Spør om allergier?",
-      name: "allergy",
+      name: "onlyOpenForInternal",
+      title: "Kun åpen for interne",
+      description:
+        "Hvis du krysser av å denne vil det stå på arrangementet at det er kun for interne. Hvis ikke står det at det er åpent for alle.",
       type: "boolean",
+      options: {
+        layout: "checkbox",
+      },
     }),
     defineField({
-      title: "Legg til egne felter?",
+      name: "onlyVisibleForInternal",
+      title: "Kun synlig for interne",
+      description:
+        "Hvis du krysser av å denne vil arrangementet kun vises til interne som har logget seg inn på nettsiden. Hvis ikke vil det være synlig for alle.",
+      type: "boolean",
+      options: {
+        layout: "checkbox",
+      },
+    }),
+    defineField({
+      title: "Allergier",
+      name: "allergy",
+      description:
+        "Dersom det skal serveres mat på arrangementet, kryss av på denne slik at allergier blir lagt til i påmeldingsskjemaet.",
+      type: "boolean",
+      options: {
+        layout: "checkbox",
+      },
+    }),
+    defineField({
+      title: "Mat",
+      name: "food",
+      type: "string",
+      description:
+        "Hvis det er matservering kan du også fylle inn hva slags mat som serveres eller fra hvor, så vises det på arrangementet.",
+    }),
+    defineField({
+      title: "Legg til egne felter",
+      description:
+        "Skru på denne hvis det er flere spørsmål du vil legge til i påmeldingsskjemaet, så dukker de opp under her.",
       name: "fields",
       type: "boolean",
     }),


### PR DESCRIPTION
- Legger til tre felter i sanity:
  - `openForExternals`: Denne bestemmer om påmeldingen skal være åpen for alle eller kun for interne
  - `visibleForExternals`: Denne bestemmer om arrangementet skal være synlig for alle eller kun hvis man er logget inn
  - `food`: Dukker opp hvis man krysser av på matservering/allergier slik at mat/restaurant kan vises på arrangementet

- Legger til filtering av events på serversiden basert på om man er logget inn eller ikke